### PR TITLE
Add initial seat map functionality

### DIFF
--- a/src/geometrical_shapes.rs
+++ b/src/geometrical_shapes.rs
@@ -11,8 +11,8 @@ pub trait Displayable{
 
 #[derive(Debug, Clone, Copy)]
 pub struct Point{
-    x: i32,
-    y: i32,
+    pub x: i32,
+    pub y: i32,
 }
 
 
@@ -133,10 +133,10 @@ impl Drawable for Triangle{
 }
 
 pub struct Rectangle{
-    a:Point,
-    b:Point,
-    c:Point,
-    d:Point
+    pub a:Point,
+    pub b:Point,
+    pub c:Point,
+    pub d:Point
 }
 
 impl Rectangle{
@@ -155,6 +155,18 @@ impl Rectangle{
         line_algorithm(&l2, img, &color);
         line_algorithm(&l3, img, &color);
         line_algorithm(&l4, img, &color);
+    }
+
+    pub fn draw_filled_color(&self, img:&mut Image, color:&Color){
+        let left = self.a.x.min(self.b.x);
+        let right = self.a.x.max(self.b.x);
+        let top = self.a.y.min(self.b.y);
+        let bottom = self.a.y.max(self.b.y);
+        for x in left..right {
+            for y in top..bottom {
+                img.display(x, y, color.clone());
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 mod geometrical_shapes;
+mod seat_map;
 extern crate raster;
 
 use geometrical_shapes as gs;
 use gs::{Displayable, Drawable};
 use raster::{Color,Image};
+use seat_map::SeatMap;
 
 
 fn main() {
@@ -26,6 +28,10 @@ fn main() {
     for _ in 1..50 {
         gs::Circle::random(image.width, image.height).draw(&mut image);
     }
+
+    let start = gs::Point::new(100, 100);
+    let seatmap = SeatMap::new(5, 10, &start, 15, 5);
+    seatmap.draw(&mut image);
 
     raster::save(&image, "image.png").unwrap();
 }

--- a/src/seat_map.rs
+++ b/src/seat_map.rs
@@ -1,0 +1,54 @@
+use crate::geometrical_shapes::{Point, Rectangle, Drawable};
+use raster::{Image, Color};
+
+#[derive(Clone)]
+pub struct Seat {
+    rect: Rectangle,
+    pub tariff: u32,
+}
+
+impl Seat {
+    pub fn new(top_left: &Point, size: i32, tariff: u32) -> Self {
+        let bottom_right = Point::new(top_left.x + size, top_left.y + size);
+        let rect = Rectangle::new(top_left, &bottom_right);
+        Self { rect, tariff }
+    }
+}
+
+impl Drawable for Seat {
+    fn draw(&self, img: &mut Image) {
+        let color = match self.tariff {
+            0 => Color { r: 0, g: 255, b: 0, a: 255 },
+            1 => Color { r: 0, g: 0, b: 255, a: 255 },
+            _ => Color { r: 255, g: 0, b: 0, a: 255 },
+        };
+        self.rect.draw_filled_color(img, &color);
+    }
+}
+
+pub struct SeatMap {
+    pub seats: Vec<Seat>,
+}
+
+impl SeatMap {
+    pub fn new(rows: i32, cols: i32, start: &Point, size: i32, padding: i32) -> Self {
+        let mut seats = Vec::new();
+        for r in 0..rows {
+            for c in 0..cols {
+                let x = start.x + c * (size + padding);
+                let y = start.y + r * (size + padding);
+                let tariff = r as u32 % 3;
+                seats.push(Seat::new(&Point::new(x, y), size, tariff));
+            }
+        }
+        Self { seats }
+    }
+}
+
+impl Drawable for SeatMap {
+    fn draw(&self, img: &mut Image) {
+        for seat in &self.seats {
+            seat.draw(img);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose Point and Rectangle fields for reuse
- add filled rectangle drawing method
- implement `Seat` and `SeatMap` modules to represent a simple seating grid
- render a demo seat map in `main`

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684c10c749a0832c9ecbaa09f7e3bd9c