### PR TITLE
Add minimal pixels canvas example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "image",
  "pixels",
  "rand",
+ "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rand = "0.8.5"
 eframe = "0.31"
 iced = "0.13"
 pixels = "0.15"
+winit = "0.30"
 
 [features]
 egui-example = []
@@ -32,5 +33,10 @@ required-features = ["iced-example"]
 [[example]]
 name = "pixels_seat_map"
 path = "examples/pixels_seat_map.rs"
+required-features = ["pixels-example"]
+
+[[example]]
+name = "pixels_canvas"
+path = "examples/pixels_canvas.rs"
 required-features = ["pixels-example"]
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ display:
 - **egui/eframe** – immediate mode GUI, easy to set up. Example: `cargo run --example egui_seat_map`.
 - **iced** – Elm-inspired retained GUI library. Example: `cargo run --example iced_seat_map`.
 - **ggez** – game oriented framework with good drawing primitives. Example: `cargo run --example ggez_seat_map`.
-- **pixels** – minimal pixel frame buffer useful for custom renderers. Example:
-  `cargo run --example pixels_seat_map`.
+- **pixels** – minimal pixel frame buffer useful for custom renderers. Examples:
+  `cargo run --example pixels_seat_map` or `cargo run --example pixels_canvas`.
 
 The existing drawing code operates on an in-memory image and simple shapes. The
 `pixels` crate maps well to this design because it lets us upload our buffer

--- a/examples/pixels_canvas.rs
+++ b/examples/pixels_canvas.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "pixels-example")]
+use pixels::{Pixels, SurfaceTexture};
+use std::sync::Arc;
+use winit::{
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
+
+fn main() {
+    let mut event_loop = EventLoop::new().unwrap();
+    let window = Arc::new(
+        event_loop
+            .create_window(Window::default_attributes().with_title("Pixels Canvas"))
+            .unwrap(),
+    );
+
+    let mut pixels = {
+        let size = window.inner_size();
+        Pixels::new(
+            size.width,
+            size.height,
+            SurfaceTexture::new(size.width, size.height, window.clone()),
+        )
+        .unwrap()
+    };
+
+    event_loop
+        .run(move |event, elwt| {
+            elwt.set_control_flow(ControlFlow::Wait);
+            match event {
+                Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::CloseRequested => elwt.exit(),
+                    WindowEvent::Resized(size) => {
+                        let _ = pixels.resize_surface(size.width, size.height);
+                    }
+                    WindowEvent::RedrawRequested => {
+                        for pixel in pixels.frame_mut().chunks_exact_mut(4) {
+                            pixel.copy_from_slice(&[0x20, 0x20, 0x20, 0xff]);
+                        }
+                        let _ = pixels.render();
+                    }
+                    _ => {}
+                },
+                Event::AboutToWait => {
+                    window.request_redraw();
+                }
+                _ => {}
+            }
+        })
+        .unwrap();
+}


### PR DESCRIPTION
## Summary
- add `winit` dev dependency and register new `pixels_canvas` example
- document `pixels_canvas` example in README
- implement `examples/pixels_canvas.rs` using the modern `winit` API

## Testing
- `cargo check --example pixels_canvas --features pixels-example`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c23956fe4832c9eaa5cd914bb7d79