### PR TITLE
Add GUI output with Pixels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 image = "0.25"
 rand = "0.8.5"
+pixels = "0.15"
+winit = "0.30"
 
 [dev-dependencies]
 eframe = "0.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,55 @@
-use drawing::interactive;
+use drawing::seat_map::SeatMap;
+use drawing::geometrical_shapes::{Point, Drawable};
+use drawing::simple_image::Image;
+use pixels::{Pixels, SurfaceTexture};
+use std::sync::Arc;
+use winit::{event::{Event, WindowEvent}, event_loop::{ControlFlow, EventLoop}, window::Window};
 
 fn main() {
-    interactive::run();
+    let event_loop = EventLoop::new().unwrap();
+    let window = Arc::new(
+        event_loop
+            .create_window(Window::default_attributes().with_title("Drawing Preview"))
+            .unwrap(),
+    );
+
+    let mut pixels = {
+        let size = window.inner_size();
+        Pixels::new(
+            size.width,
+            size.height,
+            SurfaceTexture::new(size.width, size.height, window.clone()),
+        )
+        .unwrap()
+    };
+
+    let seat_map = SeatMap::new(5, 5, &Point::new(10, 10), 40, 5);
+
+    event_loop.run(move |event, elwt| {
+        elwt.set_control_flow(ControlFlow::Wait);
+        match event {
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::Resized(size) => {
+                    let _ = pixels.resize_surface(size.width, size.height);
+                }
+                WindowEvent::RedrawRequested => {
+                    let size = window.inner_size();
+                    let mut buffer = Image {
+                        width: size.width as i32,
+                        height: size.height as i32,
+                        data: pixels.frame().to_vec(),
+                    };
+                    seat_map.draw(&mut buffer);
+                    pixels.frame_mut().copy_from_slice(&buffer.data);
+                    let _ = pixels.render();
+                }
+                _ => {}
+            },
+            Event::AboutToWait => {
+                window.request_redraw();
+            }
+            _ => {}
+        }
+    }).unwrap();
 }


### PR DESCRIPTION
## Summary
- integrate `pixels` and `winit` crates as dependencies
- replace CLI-based entrypoint with pixels window to preview a generated seat map

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c26844978832cad16dc8b5bc3fb82